### PR TITLE
add `require calendar'

### DIFF
--- a/weather-metno.el
+++ b/weather-metno.el
@@ -31,6 +31,7 @@
 (require 'url)
 (require 'url-cache)
 (require 'xml)
+(require 'calendar)
 
 (require 'cl-lib)
 


### PR DESCRIPTION
To prevent from the error message like `Symbol's function definition is void: calendar-date-equal`.
